### PR TITLE
Support customizable callback url-scheme

### DIFF
--- a/Sources/SwifterAuth.swift
+++ b/Sources/SwifterAuth.swift
@@ -128,7 +128,7 @@ public extension Swifter {
         }, failure: failure)
     }
 
-    func authorizeSSO(success: SSOTokenSuccessHandler?, failure: FailureHandler? = nil) {
+    func authorizeSSO(withCallbackURLScheme urlScheme: String? = nil, success: SSOTokenSuccessHandler?, failure: FailureHandler? = nil) {
         guard let client = client as? SwifterAppProtocol else {
             let error = SwifterError(message: "SSO not supported AppOnly client",
                                      kind: .invalidClient)
@@ -136,8 +136,8 @@ public extension Swifter {
             return
         }
         
-        let urlScheme = "swifter-\(client.consumerKey)"
-        
+        let urlScheme = urlScheme ?? "swifter-\(client.consumerKey)"
+
         let nc = NotificationCenter.default
         self.swifterCallbackToken = nc.addObserver(forName: .swifterSSOCallback, object: nil, queue: .main) { notification in
             self.swifterCallbackToken = nil


### PR DESCRIPTION
SSO認証時、deeplinkに付与するcallback url schemeが `swifter-{API-KEY}` ではTwitter公式Appへ遷移後認証画面が開かない模様
`twitterkit-{API-KEY}` であれば開くが、これが原因である100%の確証は無いため、ひとまずカスタマイズ可能にすることで対応できる状態にしました